### PR TITLE
Export Questionnaire and QuestionnaireResponse

### DIFF
--- a/Sources/SpeziQuestionnaire/Export.swift
+++ b/Sources/SpeziQuestionnaire/Export.swift
@@ -1,0 +1,10 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_exported import class ModelsR4.Questionnaire
+@_exported import class ModelsR4.QuestionnaireResponse

--- a/Tests/UITests/TestApp/ExampleStandard.swift
+++ b/Tests/UITests/TestApp/ExampleStandard.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import ModelsR4
 import Spezi
 import SpeziQuestionnaire
 import SwiftUI


### PR DESCRIPTION
# Export Questionnaire and QuestionnaireResponse

## :recycle: Current situation & Problem
- Using SpeziQuestionnaire requires importing ModelsR4 or other dependencies to ensure that the host application understands the offered APIs. 

## :bulb: Proposed solution
- Explicitly exports `Questionnaire` and `QuestionnaireResponse` in the API surface.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
