### PR TITLE
Lift to ResearchKit 3.x

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,3 +37,5 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: SpeziQuestionnaire-Package.xcresult TestApp.xcresult
+    secrets:
+      token: ${{ secrets.CODECOV_TOKEN }}

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.0.0"),
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordBDHG/ResearchKit", from: "2.2.28"),
-        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR", from: "1.1.0")
+        .package(url: "https://github.com/StanfordBDHG/ResearchKit", from: "3.0.1"),
+        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR", from: "1.4.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Lift to ResearchKit 3.0

## :recycle: Current situation & Problem
SpeziQuestionnaire currently uses ResearchKit 2.x and can be updated to 3.x.

## :gear: Release Notes 
- Updates ResearchKit to 3.0.1 and ResearchKitOnFHIR to 1.4.0.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
